### PR TITLE
Fix event type

### DIFF
--- a/src/AmazonAlexaDriver.php
+++ b/src/AmazonAlexaDriver.php
@@ -69,16 +69,22 @@ class AmazonAlexaDriver extends HttpDriver
      */
     public function getMessages()
     {
-        if (empty($this->messages)) {
-            $intent = $this->event->get('intent');
-            $session = $this->payload->get('session');
+	    if (empty($this->messages)) {
+		    $type = $this->event->get('type');
+		    $intent = $this->event->get('intent');
+		    if ($type === self::LAUNCH_REQUEST || $type === self::SESSION_ENDED_REQUEST) {
+			    $name = $type;
+		    } else {
+			    $name = $intent['name'];
+		    }
+		    $session = $this->payload->get('session');
 
-            $message = new IncomingMessage($intent['name'], $session['user']['userId'], $session['sessionId'], $this->payload);
-            if (! is_null($intent) && array_key_exists('slots', $intent)) {
-                $message->addExtras('slots', Collection::make($intent['slots']));
-            }
-            $this->messages = [$message];
-        }
+		    $message = new IncomingMessage($name, $session['user']['userId'], $session['sessionId'], $this->payload);
+		    if (! is_null($intent) && array_key_exists('slots', $intent)) {
+			    $message->addExtras('slots', Collection::make($intent['slots']));
+		    }
+		    $this->messages = [$message];
+	    }
 
         return $this->messages;
     }
@@ -173,7 +179,7 @@ class AmazonAlexaDriver extends HttpDriver
         //
     }
 
-    
+
 
     public function dialogDelegate()
     {

--- a/tests/AmazonAlexaDriverTest.php
+++ b/tests/AmazonAlexaDriverTest.php
@@ -115,6 +115,20 @@ class AmazonAlexaDriverTest extends PHPUnit_Framework_TestCase
     }
 
     /** @test */
+    public function it_returns_the_message_object_for_launch()
+    {
+        $driver = $this->getValidDriver(null, 'LaunchRequest');
+        $this->assertTrue(is_array($driver->getMessages()));
+    }
+
+    /** @test */
+    public function it_returns_the_message_object_for_session_ended()
+    {
+        $driver = $this->getValidDriver(null, 'SessionEndedRequest');
+        $this->assertTrue(is_array($driver->getMessages()));
+    }
+
+    /** @test */
     public function it_detects_bots()
     {
         $driver = $this->getValidDriver();

--- a/tests/AmazonAlexaDriverTest.php
+++ b/tests/AmazonAlexaDriverTest.php
@@ -44,9 +44,10 @@ class AmazonAlexaDriverTest extends PHPUnit_Framework_TestCase
     }
   },
   "request": {
-    "type": "'.$type.'",
-    "requestId": "request_id",
-    "intent": {
+    "type": "' . $type . '",
+    "requestId": "request_id",';
+        if ($type === 'IntentRequest') {
+            $responseData .= '"intent": {
       "name": "intent_name",
       "slots": {
         "location": {
@@ -54,7 +55,9 @@ class AmazonAlexaDriverTest extends PHPUnit_Framework_TestCase
           "value": "Berlin"
         }
       }
-    },
+    },';
+        }
+        $responseData .= '
     "locale": "de-DE",
     "timestamp": "2017-09-27T20:50:37Z"
   },


### PR DESCRIPTION
Alexa payloads are different based on the request type: if the type is "IntentRequest" there is also the "name" of the intent, who is configured in the Alexa developer portal by the developer; but if the type is "LaunchRequest" or "SessionEndedRequest" there is no "name" field, resulting in an error. These special types are used from Alexa to send the first opening of the skill (when you open a skill without declaring an intent) or when it needs to be closed gracefully.

With this PR my aim is to add the management of these requests so that it doesn't break anything. Tested with unit tests and with a production application.